### PR TITLE
Adopt to 1.5.2 elasticsearch. Use GeoDistanceSortBuilder.geohashes

### DIFF
--- a/ezelastic/common/src/main/java/ezbake/data/elastic/common/ElasticUtils.java
+++ b/ezelastic/common/src/main/java/ezbake/data/elastic/common/ElasticUtils.java
@@ -148,7 +148,7 @@ public final class ElasticUtils {
         // Value
         final GeoSortValue geoVal = geoDistanceSort.getValue();
         if (geoVal.isSet(GeoSortValue._Fields.GEO_HASH)) {
-            gs.geohash(geoVal.getGeoHash());
+            gs.geohashes(geoVal.getGeoHash());
         } else {
             gs.point(geoVal.getCoordinate().getLatitude(), geoVal.getCoordinate().getLongitude());
         }


### PR DESCRIPTION
GeoDistanceSortBuilder interface has changed. New method geohashes uses varargs parameter. 
@joshbronson please review. Unit tests passed. 
